### PR TITLE
add --insert-after cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `.pre-commit-config.yaml`
 
 ```yaml
 -   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.5  # Use the ref you want to point at
+    rev: v0.0.7  # Use the ref you want to point at
     hooks:
     -   id: add-msg-issue-prefix
 ```
@@ -28,7 +28,7 @@ Change how the issue is rendered to the commit message using the `--template` ar
 
 ```yaml
 -   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.5  # Use the ref you want to point at
+    rev: v0.0.7  # Use the ref you want to point at
     hooks:
     -   id: add-msg-issue-prefix
         args:
@@ -42,7 +42,7 @@ Customize where the issue key is inserted using regular expressions. The followi
 
 ```yaml
 -   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.5  # Use the ref you want to point at
+    rev: v0.0.7  # Use the ref you want to point at
     hooks:
     - id: add-msg-issue-prefix
         name: add-msg-issue-prefix-test

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pre-commit install --hook-type prepare-commit-msg
 ```
 
 ### Optional template argument
+
 Change how the issue is rendered to the commit message using the `--template` argument.
 
 ```yaml
@@ -33,4 +34,17 @@ Change how the issue is rendered to the commit message using the `--template` ar
         args:
             - --template=[{}]
 
+```
+
+### Optional insert after argument
+
+Customize where the issue key is inserted using regular expressions. The following example allows commit messages of the form `feat: add feature` to be updated to `feat: [ABC-123] add feature`.
+
+```yaml
+-   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
+    rev: v0.0.5  # Use the ref you want to point at
+    hooks:
+    - id: add-msg-issue-prefix
+        name: add-msg-issue-prefix-test
+        args: ["--insert-after", "^feat.?:|^fix.?:"]
 ```

--- a/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
+++ b/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
@@ -1,31 +1,64 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
 import re
 import subprocess
 
 
 def get_ticket_id_from_branch_name(branch):
-    matches = re.findall('[a-zA-Z0-9]{1,10}-[0-9]{1,5}', branch)
+    matches = re.findall("[a-zA-Z0-9]{1,10}-[0-9]{1,5}", branch)
     if len(matches) > 0:
         return matches[0]
+
+
+def modify_commit_message(content: str, issue_number: str, pattern: re.Pattern) -> str:
+    """Inserts the issue number into the commit message after the specified regex pattern.
+
+    Args:
+        content (str): commit message contents
+        issue_number (str): issue identifier to insert
+        pattern (re.Pattern): pattern after which to insert the issue identifier
+
+    Returns: str
+
+    """
+    match = re.search(pattern, content)
+    if match:
+        return " ".join(
+            [
+                match.group().strip(),
+                issue_number.strip(),
+                content[match.end() :].strip(),
+            ]
+        )
+    return " ".join([issue_number.strip(), content])
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("commit_msg_filepath")
     parser.add_argument(
-        '-t', '--template', default="[{}]",
-        help='Template to render ticket id into',
+        "-t",
+        "--template",
+        default="[{}]",
+        help="Template to render ticket id into",
+    )
+    parser.add_argument(
+        "-i",
+        "--insert-after",
+        default="^",
+        help="Regex pattern describing the text after which to insert the issue key.",
     )
     args = parser.parse_args()
     commit_msg_filepath = args.commit_msg_filepath
     template = args.template
+    pattern = re.compile(args.insert_after)
 
     branch = ""
     try:
-        branch = subprocess.check_output(["git","symbolic-ref", "--short", "HEAD"], universal_newlines=True).strip()
+        branch = subprocess.check_output(
+            ["git", "symbolic-ref", "--short", "HEAD"], universal_newlines=True
+        ).strip()
     except Exception as e:
         print(e)
 
@@ -41,7 +74,8 @@ def main():
         f.seek(0, 0)
         if issue_number and issue_number not in content_subject:
             prefix = template.format(issue_number)
-            f.write("{} {}".format(prefix, content))
+            new_msg = modify_commit_message(content, prefix, pattern)
+            f.write(new_msg)
         else:
             f.write(content)
 


### PR DESCRIPTION
Hi @avilaton 👋  Thanks for creating this `pre-commit` hook!

My team has started using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and, unfortunately, this means that simply prepending the issue key to the commit message does not satisfy this use case.

This change allows users to configure **where** the issue key is inserted in the commit message via a configuration argument. For instance:

```yaml
repos:
  - repo: local
    hooks:
      - id: add-msg-issue-prefix
        name: add-msg-issue-prefix-test
        entry: ../add-msg-issue-prefix-hook/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
        language: python
        args: ["--insert-after", "^build.?:|^chore.?:|^ci.?:|^docs.?:|^feat.?:|^style.?:|^perf.?:|^test.?:"]
        stages: [prepare-commit-msg]
```

Results in messages looking like:

![image](https://github.com/avilaton/add-msg-issue-prefix-hook/assets/74255970/28b0685e-1223-459a-a850-a39d86a4fa82)

Note that the default behavior should be unchanged-- it should prepend the issue key by default.