### PR TITLE
Add support for default issues

### DIFF
--- a/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
+++ b/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
@@ -83,7 +83,7 @@ def main():
     template = args.template
     default = args.default
     insert_after = re.compile(args.insert_after)
-    pattern = re.compile(args.insert_after)
+    pattern = re.compile(args.pattern)
 
     branch = ""
     try:


### PR DESCRIPTION
This PR adds an additional parameter that lets a use specify a default issue prefix if one is not found by the provided regex matching.

There are some other minor syntax changes using the walrus operator for ease of readability 



fixes: #12