### PR TITLE
add_msg_issue_prefix.py: Remove prefix whitespace

### DIFF
--- a/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
+++ b/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
@@ -42,14 +42,9 @@ def modify_commit_message(content: str, issue_number: str,
 
     """
     if match := re.search(pattern, content):
-        return " ".join(
-            [
-                match.group().strip(),
-                issue_number.strip(),
-                content[match.end():].strip(),
-            ]
-        )
-    return " ".join([issue_number.strip(), content])
+        return match.group().strip() + \
+            " ".join([issue_number.strip(), content[match.end():].strip()])
+    return issue_number.strip() + " " + content
 
 
 def main():


### PR DESCRIPTION
Removes prefix whitespace so instead of getting ' [#num] namespace: Text' -> '[#num] namespace: Text'