### PR TITLE
Insert space in front of issue id when insert_after is set

### DIFF
--- a/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
+++ b/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
@@ -40,8 +40,9 @@ def modify_commit_message(content: str, issue_number: str, insert_after: re.Patt
         str: modified commit message
 
     """
-    if match := re.search(insert_after, content):
-        return match.group().strip() + issue_number.strip() + " " + content[match.end() :]
+    if insert_after.pattern != DEFAULT_INSERT_AFTER:
+        if match := re.search(insert_after, content):
+            return match.group().strip() + " " + issue_number.strip() + " " + content[match.end() :]
 
     return issue_number.strip() + " " + content
 

--- a/tests/test_add_msg_issue_prefix.py
+++ b/tests/test_add_msg_issue_prefix.py
@@ -22,7 +22,7 @@ def test_modify_commit_message_with_insert_after():
         "Lines starting\n# with '#' will be ignored, and an empty message aborts the commit.\n"
     )
     expected_result = (
-        "task:TASK-1234 \n# Please enter the commit message for your changes."
+        "task: TASK-1234 \n# Please enter the commit message for your changes."
         "Lines starting\n# with '#' will be ignored, and an empty message aborts the commit.\n"
     )
     insert_after = re.compile("^task:")


### PR DESCRIPTION
When the `insert_after` parameter is set, the issue id should be inserted with a leading space as seen in the docs. If the parameter is not set, it should just be inserted as usual (at the beginning without leading space).