### PR TITLE
Add support for regex groups

### DIFF
--- a/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
+++ b/add_msg_issue_prefix_hook/add_msg_issue_prefix.py
@@ -19,9 +19,13 @@ def get_ticket_id_from_branch_name(pattern: re.Pattern, branch: str) -> str:
         str or None: issue identifier if found, None otherwise
 
     """
-    matches = re.findall(pattern, branch)
-    if len(matches) > 0:
-        return matches[0]
+
+    # use `search` instead `findall` as just the first match is needed
+    # and `search` returns a match object which can handle groups better
+    match = re.search(pattern, branch)
+
+    # return the entire match (from arbitrary number of groups)
+    return match.group(0) if match else None
 
 
 def modify_commit_message(content: str, issue_number: str, insert_after: re.Pattern) -> str:

--- a/tests/test_add_msg_issue_prefix.py
+++ b/tests/test_add_msg_issue_prefix.py
@@ -1,5 +1,8 @@
-from add_msg_issue_prefix_hook import add_msg_issue_prefix
 import re
+
+import pytest
+
+from add_msg_issue_prefix_hook import add_msg_issue_prefix
 
 
 def test_modify_commit_message_simple():
@@ -42,3 +45,75 @@ def test_modify_commit_message_insert_after_not_found():
 
     result = add_msg_issue_prefix.modify_commit_message(content, issue_number, insert_after)
     assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "pattern, branch_name, expected_ticket_id",
+    [
+        (r"TASK-\d+", "feature/TASK-1234-add-new-feature", "TASK-1234"),  # simple match
+        (r"TASK-\d+", "feature/add-new-feature", None),  # no match
+        (r"TASK-\d+", "feature/TASK-1234-and-TASK-5678", "TASK-1234"),  # first match
+    ],
+)
+def test_get_ticket_id_from_branch_name_basic_parametrized(
+    pattern, branch_name, expected_ticket_id
+):
+    """
+    Parametrized test for the extraction of a ticket ID from a branch name.
+
+    It tests for the correct handling of basic regex patterns, to ensure the correct match
+    (the first one) is returned.
+    """
+    ticket_id = add_msg_issue_prefix.get_ticket_id_from_branch_name(
+        pattern=pattern, branch=branch_name
+    )
+    assert ticket_id == expected_ticket_id, (
+        f"Failed for pattern: {pattern}, branch_name: {branch_name}, getting wrong ticket_id: {ticket_id}"
+    )
+
+
+@pytest.mark.parametrize(
+    "pattern, branch_name, expected_ticket_id",
+    [
+        (  # two groups
+            r"(TASK-\d+)|(BUG-\d+)",
+            "feature/TASK-1234-add-new-feature",
+            "TASK-1234",
+        ),
+        (  # two groups, match the second
+            r"(TASK-\d+)|(BUG-\d+)",
+            "bugfix/BUG-1234-add-new-feature",
+            "BUG-1234",
+        ),
+        (  # one group and additional part without group
+            r"(TASK|BUG|FEATURE)-\d+",
+            "feature/FEATURE-1234-add-new-feature",
+            "FEATURE-1234",
+        ),
+        (  # regex with lookahead
+            r"(?<=feature/)(TASK|BUG)-\d+",
+            "feature/TASK-9999-add-new-feature",
+            "TASK-9999",
+        ),
+        (  # nested groups
+            r"((?<=feature/)(TASK|BUG|FEATURE)-\d+)",
+            "feature/FEATURE-1234-add-new-feature",
+            "FEATURE-1234",
+        ),
+    ],
+)
+def test_get_ticket_id_from_branch_name_using_regex_groups_parametrized(
+    pattern, branch_name, expected_ticket_id
+):
+    """
+    Parametrized test for the extraction of a ticket ID from a branch name.
+
+    It tests for the correct handling of regex patterns containing one or more groups.
+    """
+
+    ticket_id = add_msg_issue_prefix.get_ticket_id_from_branch_name(
+        pattern=pattern, branch=branch_name
+    )
+    assert ticket_id == expected_ticket_id, (
+        f"Failed for pattern: {pattern}, branch_name: {branch_name}, getting wrong ticket_id: {ticket_id}"
+    )


### PR DESCRIPTION
Fix for issue https://github.com/avilaton/add-msg-issue-prefix-hook/issues/26

## What has been done in this PR
* modified method `get_ticket_id_from_branch_name`:
   * switching to `re.search` as this supports groups better
   * adding tests for the existing + new functionality

## Why is this change needed
When providing a regex that contains groups e.g. 
   regex: `r"(TASK|BUG|FEATURE)-\d+"` 
   branch: `feature/TASK-1234-add-new-feature`

then just the match belonging to the first group is taken into account as issue id, in this example `TASK` instead `TASK-1234`.